### PR TITLE
Add ubTrace support for pre-built CI output

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ extensions = [
     "sphinx_codelinks",
     "sphinxcontrib.mermaid",
     "sphinxcontrib.test_reports",
+    "ubt_sphinx",
 ]
 
 intersphinx_mapping = {
@@ -52,6 +53,21 @@ intersphinx_mapping = {
 # the project. Declarative configuration formats are also preferred as they
 # cannot contain logic and can be consumed by almost all languages.
 needs_from_toml = "ubproject.toml"
+
+###############################################################################
+# UBTRACE Config START
+###############################################################################
+
+# ubTrace project properties used by the ``ubtrace`` Sphinx builder.
+# Build with:  UBTRACE_VERSION=1.0 uv run sphinx-build -b ubtrace docs docs/_build/ubtrace
+# See https://ubtrace.useblocks.com for details.
+ubtrace_organization = "useblocks"
+ubtrace_project = "x-as-code"
+ubtrace_version = os.environ.get("UBTRACE_VERSION", version)
+
+###############################################################################
+# UBTRACE Config END
+###############################################################################
 
 needs_string_links = {
     # Adds link to the Sphinx-Needs configuration page

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "furo>=2024.8.6",
     "sphinxcontrib-mermaid>=1.0.0",
     "sphinx-test-reports>=1.3.2",
+    "ubt-sphinx>=0.4.0",
 ]
 readme = "README.md"
 requires-python = ">= 3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -361,6 +361,18 @@ wheels = [
 ]
 
 [[package]]
+name = "cssutils"
+version = "2.11.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/9f/329d26121fe165be44b1dfff21aa0dc348f04633931f1d20ed6cf448a236/cssutils-2.11.1.tar.gz", hash = "sha256:0563a76513b6af6eebbe788c3bf3d01c920e46b3f90c8416738c5cfc773ff8e2", size = 711657, upload-time = "2024-06-04T15:51:39.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/ec/bb273b7208c606890dc36540fe667d06ce840a6f62f9fae7e658fcdc90fb/cssutils-2.11.1-py3-none-any.whl", hash = "sha256:a67bfdfdff4f3867fab43698ec4897c1a828eca5973f4073321b3bccaf1199b1", size = 385747, upload-time = "2024-06-04T15:51:37.499Z" },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -410,11 +422,11 @@ wheels = [
 
 [[package]]
 name = "docutils"
-version = "0.21.2"
+version = "0.20.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/53/a5da4f2c5739cf66290fac1431ee52aff6851c7c8ffd8264f13affd7bcdd/docutils-0.20.1.tar.gz", hash = "sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b", size = 2058365, upload-time = "2023-05-16T23:39:19.748Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
+    { url = "https://files.pythonhosted.org/packages/26/87/f238c0670b94533ac0353a4e2a1a771a0cc73277b88bff23d3ae35a256c1/docutils-0.20.1-py3-none-any.whl", hash = "sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6", size = 572666, upload-time = "2023-05-16T23:39:15.976Z" },
 ]
 
 [[package]]
@@ -431,6 +443,7 @@ dependencies = [
     { name = "sphinx-test-reports" },
     { name = "sphinxcontrib-mermaid" },
     { name = "sphinxcontrib-plantuml" },
+    { name = "ubt-sphinx" },
 ]
 
 [package.metadata]
@@ -444,6 +457,7 @@ requires-dist = [
     { name = "sphinx-test-reports", specifier = ">=1.3.2" },
     { name = "sphinxcontrib-mermaid", specifier = ">=1.0.0" },
     { name = "sphinxcontrib-plantuml", specifier = ">=0.30" },
+    { name = "ubt-sphinx", specifier = ">=0.4.0" },
 ]
 
 [[package]]
@@ -572,6 +586,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
 ]
+
+[[package]]
+name = "jsmin"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/73/e01e4c5e11ad0494f4407a3f623ad4d87714909f50b17a06ed121034ff6e/jsmin-3.0.1.tar.gz", hash = "sha256:c0959a121ef94542e807a674142606f7e90214a2b3d1eb17300244bbb5cc2bfc", size = 13925, upload-time = "2022-01-16T20:35:59.13Z" }
 
 [[package]]
 name = "jsonschema"
@@ -919,6 +939,15 @@ wheels = [
 ]
 
 [[package]]
+name = "more-itertools"
+version = "10.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1253,6 +1282,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rcssmin"
+version = "1.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/ea/97b6a726af92460b096283a8f906860327f946b4fb86c2a810697646236f/rcssmin-1.1.3.tar.gz", hash = "sha256:cc66240a760476e4c014bf647650a5c5a1bd9b26734c3fc389a190ebff0bfd60", size = 580660, upload-time = "2024-10-12T21:08:53.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/fe/80674c38061b55cd8ef029e005340dae06adcc5f497fb4d460fc0d17b6e3/rcssmin-1.1.3-cp312-cp312-manylinux1_i686.whl", hash = "sha256:65d8cbc01fdad4e9537bc1e33648d6a5af0e1e2df8291e7b8ccd8d9c51669f8e", size = 48628, upload-time = "2024-10-12T21:09:29.141Z" },
+    { url = "https://files.pythonhosted.org/packages/66/2d/6bdd7e0578d987ebf1d331cea884cdb26e8dbc589506362ba8c0ed84829a/rcssmin-1.1.3-cp312-cp312-manylinux1_x86_64.whl", hash = "sha256:ba61ae028f5e8cab77aab8af4db6690e1b0cf48549ffc3182e2de7d895749a6e", size = 48097, upload-time = "2024-10-12T21:09:30.358Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f0/23e99288e9df6156113ea5ce9c872eedd221555a10d6f802707d16195197/rcssmin-1.1.3-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:01bd93a6678ef4d3722501d13e659007443f536b21e6a7eee731353d755f824e", size = 49345, upload-time = "2024-10-12T21:09:31.857Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b5/1ea49711325436f981484824c40762d5e251dd5797e2185dcebdfc619e74/rcssmin-1.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:534a6af517d7fe7fefb3e7ceb3284c17bb6b10891f11b19f29b614db40e243af", size = 52622, upload-time = "2024-10-12T21:09:33.746Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/e9/451890f7c56fdb5677e128dacd182d33fae4e09ffec4d8145326fbdfef12/rcssmin-1.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:d614d39d1ed28ee017d2f1886c500b41a05dfb814e1dd8bbf9d6bf2238698d22", size = 52163, upload-time = "2024-10-12T21:09:34.96Z" },
+    { url = "https://files.pythonhosted.org/packages/06/de/4bac440a88507b66657eb7cd5669f13a642b8c7777a5ee19e16b5bc5a6d4/rcssmin-1.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2694c5bc030a6403e2b1191978ad9ae9cfe2562be1173dae287ee11705736565", size = 51869, upload-time = "2024-10-12T21:09:36.796Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ae/59954253d7c21497f976a359c73c39071735517f21ef6bdd3f0853d358cb/rcssmin-1.1.3-cp313-cp313-manylinux1_i686.whl", hash = "sha256:4076acc5a4d5b62ddc6fea3b81c0c2af63d0d07defd44d3c3a3c94a45ed3f02f", size = 48615, upload-time = "2024-10-12T21:09:38.28Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6d/8abe97c108bbf593ee2c9779787b196dd438e37f74e858e146735f638e78/rcssmin-1.1.3-cp313-cp313-manylinux1_x86_64.whl", hash = "sha256:e2682a857600688d701d2880b58607228d6ef2c1762b83779b91245c29446111", size = 48058, upload-time = "2024-10-12T21:09:39.902Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/5d/aba7d40ee8e21ef8e7980081b2221fe3f5c010773af0de668b66f80aca6e/rcssmin-1.1.3-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:11e57254cf2ae7f0efddf3bf9714b7e15a31b99d9f8350baba5b6d70768c4b52", size = 49303, upload-time = "2024-10-12T21:09:41.074Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/7e/e5ba51117868807bcc74cb74ead7b3c05f1816246fb8764df6c8502f53c7/rcssmin-1.1.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:007da259946a4bd435784cb6292313e909c0f3c4670a49887b615aafa3f5d132", size = 52304, upload-time = "2024-10-12T21:09:42.266Z" },
+    { url = "https://files.pythonhosted.org/packages/84/23/f62ae1404e158de10a5a628d00f164148c1f751a1495886c915dd07ca988/rcssmin-1.1.3-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:8039915f5417869917a391e25f8ac365a5e308c9f3ae8d3f1cf4deff11788687", size = 51906, upload-time = "2024-10-12T21:09:43.433Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8d/248a7f3d5aad5331f9cbda1d48006c0f7e9ac6734776bc6c6600f0eb44e8/rcssmin-1.1.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:07a47e8dd378a02e8f875e978c7f2e1fda7148eca939793bd30ed56e00c96de4", size = 51571, upload-time = "2024-10-12T21:09:44.672Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/4c/475fdeac9a1a769f8b58bf672ff0abe8c19cea632ffd567c01b392849f20/rcssmin-1.1.3-cp313-cp313t-manylinux1_i686.whl", hash = "sha256:82fa867cbbbec9e20f5d0b84d00c067e34d36bf57dcb0043041fb8a5e450bd42", size = 50828, upload-time = "2024-10-12T21:09:46.742Z" },
+    { url = "https://files.pythonhosted.org/packages/65/47/8b685ace57d0246f9918d02ffce1b3234112e11bc670ffd257adbf4922a4/rcssmin-1.1.3-cp313-cp313t-manylinux1_x86_64.whl", hash = "sha256:92eca89fab8706710191beff331c1eed7cb8fa6524a9bddaeb65e5a8097cadd3", size = 50460, upload-time = "2024-10-12T21:09:48.004Z" },
+    { url = "https://files.pythonhosted.org/packages/58/09/a8470dc2d36b12444479ea8ba6b72ec036d4e067e4c6abd7e2877c4f0091/rcssmin-1.1.3-cp313-cp313t-manylinux2014_aarch64.whl", hash = "sha256:345f85516535ea1e27e3f219c0308bb001db12f55f904eefb4db6e10a602cfa1", size = 52082, upload-time = "2024-10-12T21:09:49.468Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/b3/3533a526cb91a732f2bec7f20bf4de4021a360a1115e07755c44317afbe0/rcssmin-1.1.3-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:b28f0e46a6fe34a09bb497a9ddb7ad3996f315806d09202605c76e7688a442d3", size = 54152, upload-time = "2024-10-12T21:09:51.21Z" },
+    { url = "https://files.pythonhosted.org/packages/41/16/ea9d89ab83f4e26155d34a2a2f6b1b89768ad6d96038834de4a1a154067b/rcssmin-1.1.3-cp313-cp313t-musllinux_1_1_i686.whl", hash = "sha256:011a553634d4d53a7291b001df8664b1c6fbd9b416cd0061f3fb66d245ab6ec8", size = 54117, upload-time = "2024-10-12T21:09:52.689Z" },
+    { url = "https://files.pythonhosted.org/packages/68/67/66d53b436afcefd6cf2e2bb03403380b9203ff4ae2a39fd7b09575f20e8b/rcssmin-1.1.3-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:afd45cc23e8bf781ac7a50474193d414f82e6b72d4db08125861965fe952ab26", size = 53721, upload-time = "2024-10-12T21:09:53.886Z" },
 ]
 
 [[package]]
@@ -1679,11 +1734,11 @@ wheels = [
 
 [[package]]
 name = "sphinxcontrib-serializinghtml"
-version = "2.0.0"
+version = "1.1.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/13/8dd7a7ed9c58e16e20c7f4ce8e4cb6943eb580955236d0c0d00079a73c49/sphinxcontrib_serializinghtml-1.1.10.tar.gz", hash = "sha256:93f3f5dc458b91b192fe10c397e324f262cf163d79f3282c158e8436a2c4511f", size = 15592, upload-time = "2024-01-13T02:51:36.827Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
+    { url = "https://files.pythonhosted.org/packages/38/24/228bb903ea87b9e08ab33470e6102402a644127108c7117ac9c00d849f82/sphinxcontrib_serializinghtml-1.1.10-py3-none-any.whl", hash = "sha256:326369b8df80a7d2d8d7f99aa5ac577f51ea51556ed974e7716cfd4fca3f6cb7", size = 92725, upload-time = "2024-01-13T02:51:34.898Z" },
 ]
 
 [[package]]
@@ -1708,6 +1763,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fd/03/6111ed99e9bf7dfa1c30baeef0e0fb7e0bd387bd07f8e5b270776fe1de3f/tinyhtml5-2.0.0.tar.gz", hash = "sha256:086f998833da24c300c414d9fe81d9b368fd04cb9d2596a008421cbc705fcfcc", size = 179507, upload-time = "2024-10-29T15:37:14.078Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/de/27c57899297163a4a84104d5cec0af3b1ac5faf62f44667e506373c6b8ce/tinyhtml5-2.0.0-py3-none-any.whl", hash = "sha256:13683277c5b176d070f82d099d977194b7a1e26815b016114f581a74bbfbf47e", size = 39793, upload-time = "2024-10-29T15:37:11.743Z" },
+]
+
+[[package]]
+name = "tomlkit"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/af/14b24e41977adb296d6bd1fb59402cf7d60ce364f90c890bd2ec65c43b5a/tomlkit-0.14.0.tar.gz", hash = "sha256:cf00efca415dbd57575befb1f6634c4f42d2d87dbba376128adb42c121b87064", size = 187167, upload-time = "2026-01-13T01:14:53.304Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/11/87d6d29fb5d237229d67973a6c9e06e048f01cf4994dee194ab0ea841814/tomlkit-0.14.0-py3-none-any.whl", hash = "sha256:592064ed85b40fa213469f81ac584f67a4f2992509a7c3ea2d632208623a3680", size = 39310, upload-time = "2026-01-13T01:14:51.965Z" },
 ]
 
 [[package]]
@@ -1823,6 +1887,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "ubt-runtime"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/2c/09ea61e2ae5b35b6dfe974b7dfb65ed4f6d08e9d0f5b9c0a241dd3b1c7fa/ubt_runtime-0.4.0-py3-none-any.whl", hash = "sha256:311e83dc370dffd04bf4d822aec6314734edf6fc8971d8a3b70f5e2efd43e962", size = 1582407, upload-time = "2025-09-08T20:12:45.009Z" },
+]
+
+[[package]]
+name = "ubt-sphinx"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cssutils" },
+    { name = "docutils" },
+    { name = "jsmin" },
+    { name = "rcssmin" },
+    { name = "sphinx" },
+    { name = "sphinxcontrib-plantuml" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomlkit" },
+    { name = "ubt-runtime" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/1d/0b89f6385b6898d3e5fecfcd6b3c566bf232700480ae76a5431ef001a46a/ubt_sphinx-0.4.0-py3-none-any.whl", hash = "sha256:a8aa953882f0c4ec78b9485848311d67159a27206c66f97653999ab660c3cdb4", size = 170798, upload-time = "2025-09-08T20:12:46.2Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `ubt-sphinx>=0.4.0` as a dependency
- Register `ubt_sphinx` extension in `conf.py`
- Configure `ubtrace_organization`, `ubtrace_project`, and `ubtrace_version` so the `ubtrace` Sphinx builder works out of the box

Customers can now build ubTrace-compatible output directly from the repo without any local modifications.

## Usage

Build ubTrace-compatible output:

```bash
UBTRACE_VERSION=1.0 uv run sphinx-build -b ubtrace docs docs/_build/ubtrace
```

Import into ubTrace:

```bash
make import-build SRC=docs/_build/ubtrace/useblocks/x-as-code/1.0 \
  ORG=useblocks PROJECT=x-as-code VERSION=1.0
```

## Test plan
- [x] `sphinx-build -b ubtrace` produces valid output (`needs.json`, `*.fjson`, `ubtrace_project.toml`)
- [x] `sphinx-build -b html` still works unchanged
- [x] Output imports successfully into ubTrace via `make import-build`

## Issue

closes #29 